### PR TITLE
Fixes off by one date errors from March 11, 2013

### DIFF
--- a/PMCalendar/src/NSDate+Helpers.m
+++ b/PMCalendar/src/NSDate+Helpers.m
@@ -96,7 +96,7 @@
 
 - (NSInteger) daysSinceDate:(NSDate *) date
 {
-    return [self timeIntervalSinceDate:date] / (60 * 60 * 24);
+    return round([self timeIntervalSinceDate:date] / (60 * 60 * 24));
 }
 
 - (BOOL) isBefore:(NSDate *) date

--- a/PMCalendar/src/PMCalendarView.m
+++ b/PMCalendar/src/PMCalendarView.m
@@ -421,7 +421,7 @@
     NSInteger monthStartDay = [monthStartDate weekday];
     monthStartDay           = (monthStartDay + (self.mondayFirstDayOfWeek?5:6)) % 7;
 
-    NSInteger daysSinceMonthStart = [date timeIntervalSinceDate:monthStartDate] / (60 * 60 *24);
+    NSInteger daysSinceMonthStart = [date daysSinceDate:monthStartDate];
     return daysSinceMonthStart + monthStartDay;
 }
 
@@ -730,10 +730,10 @@
     //Find number of days in previous month
     NSDate *prevDateOnFirst = [[_currentDate dateByAddingMonths:-1] monthStartDate];
     int numDaysInPrevMonth = [prevDateOnFirst numberOfDaysInMonth];
-    NSDate *firstDateInCal = [monthStartDate dateByAddingDays:(-weekdayOfFirst + 2)];
+    NSDate *firstDateInCal = [monthStartDate dateByAddingDays:(-weekdayOfFirst + 1)];
     
-    int selectionStartIndex = [[self.selectedPeriod normalizedPeriod].startDate daysSinceDate:firstDateInCal] + 1;
-    int selectionEndIndex = [[self.selectedPeriod normalizedPeriod].endDate daysSinceDate:firstDateInCal] + 1;
+    int selectionStartIndex = [[self.selectedPeriod normalizedPeriod].startDate daysSinceDate:firstDateInCal];
+    int selectionEndIndex = [[self.selectedPeriod normalizedPeriod].endDate daysSinceDate:firstDateInCal];
     NSDictionary *todayBGDict = [[PMThemeEngine sharedInstance] themeDictForType:PMThemeCalendarDigitsTodayElementType
                                                                          subtype:PMThemeBackgroundSubtype];
     NSDictionary *todaySelectedBGDict = [[PMThemeEngine sharedInstance] themeDictForType:PMThemeCalendarDigitsTodaySelectedElementType

--- a/PMCalendar/src/PMPeriod.m
+++ b/PMCalendar/src/PMPeriod.m
@@ -48,7 +48,7 @@
 
 - (NSInteger) lengthInDays
 {
-    return [self.endDate timeIntervalSinceDate:self.startDate] / (60 * 60 * 24);
+    return [self.endDate daysSinceDate:self.startDate];
 }
 
 - (NSString *) description


### PR DESCRIPTION
```
Fix rounding errors caused by coercing an NSTimeInterval into an NSInteger without rounding. fixes #16

* Rework calculations so that `firstDateInCal` actually corresponds to the first date in the calendar
* Change all calculations of time intervals in days to use `[NSDate daysSinceDate:]`
```
