### PR TITLE
Fixed iOS 6 compatibility

### DIFF
--- a/PMCalendar/src/PMCalendarView.m
+++ b/PMCalendar/src/PMCalendarView.m
@@ -168,7 +168,13 @@
         CGSize sz = CGSizeZero;
         if(dayFont)
         {
-            sz = [dayTitle sizeWithAttributes:@{NSFontAttributeName:dayFont}];
+            if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+                
+                sz = [dayTitle sizeWithAttributes:@{NSFontAttributeName:dayFont}];
+            }
+            else {
+                sz = [dayTitle sizeWithFont:dayFont constrainedToSize:(CGSize){width, CGFLOAT_MAX}];
+            }
         }
         
         CGRect dayHeaderFrame = CGRectMake(floor(i * hDiff) - 1
@@ -186,12 +192,25 @@
     
     int month = currentMonth;
     int year = currentYear;
+
     
 	NSString *monthTitle = [NSString stringWithFormat:@"%@ %d", [monthTitles objectAtIndex:(month - 1)], year];
     //// Month Header Drawing
     //[monthTitle sizeWithFont:monthFont]
+    
+    CGSize monthTitleSize;
+    
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+        
+        monthTitleSize = [monthTitle sizeWithAttributes:@{NSFontAttributeName:monthFont}];
+        
+    } else {
+        
+        monthTitleSize = [monthTitle sizeWithFont:monthFont];
+    }
+    
     CGRect textFrame = CGRectMake(0
-                                  , (headerHeight - [monthTitle sizeWithAttributes:@{NSFontAttributeName:monthFont}].height) / 2
+                                  , (headerHeight - monthTitleSize.height) / 2
                                   , width
                                   , monthFont.pointSize);
     

--- a/PMCalendar/src/PMThemeEngine.m
+++ b/PMCalendar/src/PMThemeEngine.m
@@ -327,7 +327,13 @@ static PMThemeEngine* sharedInstance;
     CGSize sz = CGSizeZero;
     if(usedFont)
     {
-        sz = [string sizeWithAttributes:@{NSFontAttributeName:usedFont}];
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+        
+            sz = [string sizeWithAttributes:@{NSFontAttributeName:usedFont}];
+        } else {
+            
+            sz = [string sizeWithFont:usedFont];
+        }
     }
     
     


### PR DESCRIPTION
CGSize sizeWithAttributes: method doesn't exist in iOS6; crash results.  Added an iOS version check.  Uses sizeWithFont: for iOS 6 devices, and sizeWithAttributes: for iOS 7+.
